### PR TITLE
Format instance number properly to have 2 digits

### DIFF
--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -180,7 +180,7 @@ def installed(
                 conf_file=config_file,
                 sid=sid.upper(),
                 password=password,
-                number=inst,
+                number='{:0>2}'.format(inst),
                 root_user=root_user,
                 root_password=root_password,
                 sapadm_password=sapadm_password,

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -126,7 +126,7 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                                            'hana.install': mock_install,
                                            'file.remove': mock_remove}):
             assert hanamod.installed(
-                'prd', '00', 'pass', '/software',
+                'prd', 0, 'pass', '/software',
                 'root', 'pass',
                 system_user_password='sys_pass',
                 sapadm_password='pass',


### PR DESCRIPTION
Format instance number properly to have 2 digits
in configuration file creation

This PR is created with combination of the other PR regarding this instance number modification. In this case this has to be updated here as the instance number is used to modify the hana installation configuration file