### PR TITLE
Remove python shaptools dependency from spec file

### DIFF
--- a/salt-saphana.changes
+++ b/salt-saphana.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 23 14:40:53 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Remove python shaptools dependency from spec file 
+
+-------------------------------------------------------------------
 Mon Mar  4 15:17:24 UTC 2019 - xarbulu@suse.com
 
 - Improved the use of keystore access. When the key_name is informed,

--- a/salt-saphana.spec
+++ b/salt-saphana.spec
@@ -18,7 +18,6 @@
 
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           salt-saphana
 Version:        0.3.0
 Release:        1
@@ -29,9 +28,6 @@ Url:            https://github.com/SUSE/%{name}
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires:       %{python_module shaptools}
-
-%define fname hana
 
 %description
 Salt modules and states for SAP HANA


### PR DESCRIPTION
As python shaptools is the module used in the minions
(or local if executed as minion) it shouldn't be
a hard requirement